### PR TITLE
fix: repo name in mkdocs config

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,7 +7,7 @@ docs_dir: 'docs'
 site_dir: 'build'
 
 # site info
-repo_name: 'forests/rio-stac-io'
+repo_name: 'planetlabs/rio-stac-io'
 repo_url: 'https://github.com/planetlabs/rio-stac-io'
 site_url: 'https://planetlabs.github.io/rio-stac-io'
 # social


### PR DESCRIPTION
The header currently displays what I assume was the repo's original location.

<img width="281" height="58" alt="image" src="https://github.com/user-attachments/assets/26c437de-97b1-48a3-b8ea-09f279e016f8" />
